### PR TITLE
Add 360° Camera Plugin to marketplace

### DIFF
--- a/src/content/plugins/360-camera.json
+++ b/src/content/plugins/360-camera.json
@@ -1,0 +1,37 @@
+{
+    "id": "community:lichtfeld-360",
+    "namespace": "community",
+    "name": "lichtfeld-360",
+    "displayName": "360° Camera Plugin",
+    "summary": "Convert equirectangular 360° video into masked COLMAP datasets for 3DGS training.",
+    "description": "Automated pipeline for extracting and masking frames from equirectangular video, reframing them into pinhole perspectives using presets, and importing into Lichtfeld Studio for training.",
+    "author": "Alex Gee",
+    "latestVersion": "0.1.0",
+    "lichtfeldVersion": ">=0.5.0",
+    "pluginApi": ">=1,<2",
+    "requiredFeatures": [],
+    "downloads": 0,
+    "keywords": ["360", "equirectangular", "reframe", "masking", "pinhole", "colmap", "photogrammetry", "sam3", "erp", "video"],
+    "repository": "https://github.com/alexmgee/lichtfeld-360-plugin",
+    "versions": [
+      {
+        "version": "0.1.0",
+        "pluginApi": ">=1,<2",
+        "lichtfeldVersion": ">=0.5.0",
+        "requiredFeatures": [],
+        "dependencies": [
+          "huggingface-hub==1.9.0",
+          "opencv-python-headless",
+          "numpy",
+          "pycolmap",
+          "static-ffmpeg",
+          "sam2==1.1.0",
+          "ultralytics>=8.4.33",
+          "segment-anything>=1.0",
+          "torch>=2.11.0",
+          "torchvision>=0.26.0"
+        ],
+        "gitRef": "main"
+      }
+    ]
+  }


### PR DESCRIPTION
Adds the **360° Camera Plugin** to the plugin marketplace.

Automated pipeline for extracting and masking frames from equirectangular video, reframing them into pinhole perspectives using presets, and importing into Lichtfeld Studio for training.

Plugin repo: https://github.com/alexmgee/lichtfeld-360-plugin