### PR TITLE
Add HY-World-Mirror-2 plugin to marketplace

### DIFF
--- a/src/content/plugins/hy-world-mirror-2.json
+++ b/src/content/plugins/hy-world-mirror-2.json
@@ -1,0 +1,38 @@
+{
+  "id": "community:hy-world-mirror-2",
+  "namespace": "community",
+  "name": "hy-world-mirror-2",
+  "displayName": "HY World Mirror 2.0",
+  "summary": "Feed-forward 3D reconstruction from images, video, or COLMAP via Tencent HunyuanWorld-Mirror 2.0.",
+  "description": "Runs Tencent HY-World-Mirror 2.0 on an image folder, video file, or existing COLMAP workspace and pushes Gaussian splats + camera poses + a point cloud straight into the LichtFeld scene — ready to view, train, or export. Supports direct in-memory trainer hand-off (no disk I/O), bf16 inference, calibrated VRAM auto-fit, and an image-subset picker for stride-sampling large frame folders.",
+  "author": "Yehe Liu",
+  "latestVersion": "0.1.0",
+  "lichtfeldVersion": ">=0.5.0",
+  "pluginApi": ">=1,<2",
+  "requiredFeatures": [],
+  "downloads": 0,
+  "keywords": ["hunyuan", "worldmirror", "tencent", "feed-forward", "3d-reconstruction", "gaussian-splatting", "images", "video", "colmap", "bf16"],
+  "repository": "https://github.com/lyehe/Lichtfeld-HYWorld2-Plugin",
+  "versions": [
+    {
+      "version": "0.1.0",
+      "pluginApi": ">=1,<2",
+      "lichtfeldVersion": ">=0.5.0",
+      "requiredFeatures": [],
+      "dependencies": [
+        "gsplat==1.5.3",
+        "huggingface-hub",
+        "torch==2.11.0",
+        "torchvision==0.26.0",
+        "safetensors",
+        "numpy",
+        "einops",
+        "omegaconf",
+        "opencv-python",
+        "pillow",
+        "plyfile"
+      ],
+      "gitRef": "main"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `src/content/plugins/hy-world-mirror-2.json` — a new community plugin entry for the feed-forward 3D reconstruction plugin that wraps Tencent HY-World-Mirror 2.0 for LichtFeld Studio.
- Follows the same shape as `360-camera.json` / `splat-ready.json`; passes the Zod schema in `src/content/config.ts`.

## Plugin summary
HY World Mirror 2.0 reconstructs a scene from an image folder, a video, or an existing COLMAP workspace and pushes Gaussian splats + camera poses + a point cloud straight into the LichtFeld scene — either fully in-memory (trainer hand-off via `lf.prepare_training_from_scene()`) or as a disk-persisted COLMAP dataset. Features an image-subset picker (slider + per-frame toggles), bf16 on Ampere+, calibrated VRAM auto-fit, and torch.compile with cached Inductor/Triton artifacts.

- Repo: https://github.com/lyehe/Lichtfeld-HYWorld2-Plugin
- Version: 0.1.0 · LFS >=0.5.0 · plugin_api >=1,<2 · no required features
- License: MIT (model weights downloaded from HuggingFace under their respective licenses)

## Test plan
- [x] Ran `json.load` on the new file — parses clean UTF-8
- [x] Verified field types against the Zod schema in `src/content/config.ts`
- [x] `id == namespace:name`, `latestVersion == versions[0].version`, `pluginApi/lichtfeldVersion` match between top-level and the version entry
- [ ] Astro build (can't run locally — defer to CI)